### PR TITLE
Makefile to build and simulate counter using iverilog and gtkwave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+sim/
 
 # gitignore template for Xilinx Vivado Design Suite
 # website: https://www.xilinx.com/support/download.html

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+SRC_DIRS := ./src
+BUILD_DIR := ./build
+SIM_DIR := ./sim
+SRC_FILES := $(shell find $(SRC_DIRS) -name '*.sv' -or -name '*.v')
+
+all: counter
+
+counter: $(SIM_DIR)/counter_dump.vcd
+
+$(SIM_DIR)/counter_dump.vcd: $(BUILD_DIR)/tb_counter.vvp
+	vvp $^
+	mkdir -p $(dir $@)
+	mv dump.vcd $@
+
+$(BUILD_DIR)/tb_counter.vvp: $(SRC_FILES)
+	mkdir -p $(dir $@)
+	iverilog -o $@ -s tb_counter $^
+
+.PHONY: clean
+clean:
+	rm -r $(BUILD_DIR) ${SIM_DIR}

--- a/src/tb_counter.sv
+++ b/src/tb_counter.sv
@@ -21,6 +21,7 @@ module tb_counter ();
         clk = ~clk;
 
     initial begin
+        $dumpvars(0, tb_counter);
         // pause counter
         enable <= 0;
 


### PR DESCRIPTION
Install `icarus-verilog` (open source verilog compiler) and `gtkwave` (simulation waveform viewer)

Run ``make counter`` at the root of repository to build and simulate counter
Run ``gtkwave sim/counter_dump.vcd &`` to view the waveform from simulation.

``make`` without arguments will call ``make counter`` by default.